### PR TITLE
Pass maxSubstringLength as parameter

### DIFF
--- a/JSONCrush.js
+++ b/JSONCrush.js
@@ -4,9 +4,9 @@
 
 "use strict";
 
-const JSONCrush=(string)=>
+const JSONCrush=(string, maxSubstringLength)=>
 {
-    const maxSubstringLength = 50; // speed it up by limiting max length
+    maxSubstringLength = maxSubstringLength || 50; // speed it up by limiting max length
     const delimiter = '\u0001'; // used to split parts of crushed string
         
     const JSCrush=(string, replaceCharacters)=>


### PR DESCRIPTION
Hi, thank you for this library. I'm using it for https://github.com/adamhwang/ita-matrix-powertools and it works really well. Performance impacts are negligible until attempting to crush more than a few URLs at a time.

The code appears to have some optimizations in terms of compression vs performance built in and I wanted to see if it could be tweaked further. This PR surfaces `maxSubstringLength` to a parameter passed through `JSONCrush()`

After running through 12 arbitrary payloads, here were the results of my test

Time (right axis) grows fairly linearly with increased substring length, but compression understandably appears to increase logarithmically:
![image](https://user-images.githubusercontent.com/3460424/93720249-727bf000-fb4d-11ea-945c-b6f7ef359ac7.png)

If we check the compression improvements against increased time, I hope it becomes clear that varying the `maxSubstringLength` could beneficial to others as well.
![image](https://user-images.githubusercontent.com/3460424/93720174-09947800-fb4d-11ea-9c74-1ab2a56be6b5.png)

In our use-case, a substring length between 9-11 seems to be the most efficient in terms of compression and performance.