### PR TITLE
Add modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tmp
+dist
+node_modules

--- a/JSONCrush.d.ts
+++ b/JSONCrush.d.ts
@@ -1,0 +1,3 @@
+//Typescript type definitions for JSONCrush
+export type JSONCrush = (string: string, maxSubstringLength?: number) => string;
+export type JSONUncrush = (string: string) => string;

--- a/README.md
+++ b/README.md
@@ -11,9 +11,26 @@ This simple system allows for excellent compression of uri encoded JSON strings 
 
 # [TRY THE LIVE DEMO!](https://killedbyapixel.github.io/JSONCrush)
 
+# Install
+
+```bash
+npm install https://github.com/KilledByAPixel/JSONCrush.git
+```
+
+`npm install` creates modules for Common JS, ES Module, and UMD modules in `/dist` folder.
+
+Alternatively, include JSONCrush.js or JSONCrush.min.js in your script;
+
 # How to Use
 
-* Include JSONCrush.js or JSONCrush.min.js in your script
+```js
+//NodeJS: Require
+const {JSONCrush, JSONUncrush} = require('JSONCrush');
+
+//ES Module import
+import {JSONCrush, JSONUncrush} from 'JSONCrush';
+```
+
 * Pass a JSON string to JSONCrush to compress it into an encoded URI component.
 * This result can be safely used in a URL.
 * To decode, first call searchParams.get() or decodeURIComponent() on the string before uncrushing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "jsoncrush",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
+    },
+    "rollup": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.36.1.tgz",
+      "integrity": "sha512-eAfqho8dyzuVvrGqpR0ITgEdq0zG2QJeWYh+HeuTbpcaXk8vNFc48B7bJa1xYosTCKx0CuW+447oQOW8HgBIZQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "JSONCrush",
+  "version": "1.0.1",
+  "description": "Compress JSON in URL friendly strings",
+  "main": "dist/JSONCrush.cjs.js",
+  "module": "dist/JSONCrush.esm.js",
+  "browser": "dist/JSONCrush.umd.js",
+  "types": "JSONCrush.d.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "rollup -c",
+    "preinstall": "npm install --ignore-scripts && npm run build"
+  },
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KilledByAPixel/JSONCrush.git"
+  },
+  "keywords": [
+    "JSON",
+    "URL",
+    "URI",
+    "compression"
+  ],
+  "author": "KilledByAPixel",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/KilledByAPixel/JSONCrush/issues"
+  },
+  "homepage": "https://github.com/KilledByAPixel/JSONCrush",
+  "devDependencies": {
+    "graceful-fs": "^4.2.4",
+    "rollup": "^2.36.1"
+  },
+  "dependencies": {}
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,30 @@
+import pkg from './package.json';
+import * as path from 'path';
+import {readFileSync, writeFileSync, existsSync, mkdirSync} from 'graceful-fs';
+
+//Before exporting rollup config:
+//* The rollup input requires a statement with exports for modules
+//* The input ./JSONCrush.js does not have exports because it may be used in
+//  contexts that do not support it. (such as ClosureCompiler)
+//* This sources JSONCrush.js, appends `exports` statement, and writes result to
+//  target .tmp/JSONCrush.js
+//* Note .tmp is in .gitignore
+const inputFileName = 'JSONCrush.js';
+const input = path.join(__dirname, inputFileName);
+const tmpDir = path.join(__dirname, '.tmp');
+if (!existsSync(tmpDir)) { mkdirSync(tmpDir); }
+const tmpInput = path.join(tmpDir, inputFileName);
+writeFileSync(tmpInput, readFileSync(input) + '\nexport {JSONCrush, JSONUncrush};');
+
+//Minimal rollup config to wrap JSONCrush in the module types cjs, es and umd
+export default {
+    input: tmpInput,
+    output: [
+        // CommonJS (for Node)
+        { file: pkg.main, format: 'cjs' },
+        // ES Module
+        { file: pkg.module, format: 'es' },
+        // browser-friendly UMD build
+        { name: 'JSONCrush', file: pkg.browser, format: 'umd' }
+    ]
+};


### PR DESCRIPTION
Addresses https://github.com/KilledByAPixel/JSONCrush/issues/12

* On install, builds modules (CommonJS, ES Module, and UMD) for JSONCrush
  * I intentionally avoided editing `JSONCrush.js` source.  There is still value in leaving `JSONCrush.js` as is.
  * There are many ways to wrap JSONCrush.js in the various module formats.  
     > I chose rollup because it does this task easily, you'll have some confidence it is correct and in the future you may wish to consider other rollup features such as minifying with `terser`, or doing some `babel` transforms, etc...  
* `rollup.config.js` is a very simple config for creating the 3 modules in the `dist` folder.
* `.tmp` and `dist` folders are in the `.gitignore` and not managed source.  The modules are built on install and put in the `dist` folder.
* Rather than refactor `JSONCrush.js` into typescript like #2, I created a minimal `JSONCrush.d.ts` that I think will satisfy most typescript users.  
   * The `types` property in the `package.json` points to `JSONCrush.d.ts` so typescript finds it automatically (if you use typescript) 
   * There is certainly value in using typescript in my opinion... but if you are more comfortable with or prefer vanilla JS, adding `JSONCrush.d.ts` is a simple solution to help typescript users and keep it out of your .js code.
* This pull request has similar goals to https://github.com/KilledByAPixel/JSONCrush/pull/10, but my solution is different.  Providing the 3 main module types people need is probably sufficient. And additional transform such as babel and minification can be performed when JSONCrush is bundled/used in upstream software projects.

Additional notes on `package.json`:
* `name` is `JSONCrush`.  Note the case!  This is different than `jsoncrush` in https://github.com/dprothero/JSONCrush/blob/master/package.json#L2.  
   * When using this repo, users must import `JSONCrush` and not `jsoncrush`
* There is no requirement that you register `JSONCrush` in the npm registry. I think it would be a good idea, but if you don't, users can install with `npm install https://github.com/KilledByAPixel/JSONCrush.git`
   * You may wish to ask for control over `jsoncrush` and retire it... or update the repo it points to.
   * Or you may resort to registering `JSONCrush`
* `main`, `module`, and `browser` properties point to the Common JS, ES Module and UMD modules respectively.  This lets the applicable JS environment pick the right source file for that environment.
* urls are pointing to https://github.com/KilledByAPixel rather than the fork https://github.com/dprothero

Before you approve/merge this pull request, you can test the install (and automatic builds of the 3 module formats):

> This installs from my fork's `addModules` branch. 
```bash
npm install git://github.com/darcyparker/JSONCrush.git#addModules
```
> The `README.md` provides instructions to install from your git repo:
```bash
npm install https://github.com/KilledByAPixel/JSONCrush.git
```

Then with nodejs 15.x (and other versions that support ES Modules):
```js
import {JSONCrush} from 'JSONCrush';
console.log(JSONCrush(JSON.stringify({test: 1})));
```

Or with earlier versions of node, you could do:
```js
const {JSONCrush, JSONUncrush} = require('JSONCrush');
console.log(JSONCrush(JSON.stringify({test: 1})));
```

The objective of this pull request is just to create thin wrappers of `JSONCrush.js` to get them into the 3 module formats.